### PR TITLE
Fixed wrong arguments set in NewAdapterDB

### DIFF
--- a/rethinkadapter.go
+++ b/rethinkadapter.go
@@ -39,8 +39,8 @@ func NewAdapter(Sessionvar r.QueryExecutor) persist.Adapter {
 	return a
 }
 
-// NewAdapter is the constructor for adapter.
-func NewAdapterDB(Sessionvar r.QueryExecutor, string database, string table) persist.Adapter {
+// NewAdapterDB is the constructor for adapter.
+func NewAdapterDB(Sessionvar r.QueryExecutor, database, table string) persist.Adapter {
 	a := &adapter{session: Sessionvar, database: database, table: table}
 	a.open()
 	// Call the destructor when the object is released.


### PR DESCRIPTION
This PR fixes next issue:
```
# github.com/adityapandey9/rethinkdb-adapter
vendor/github.com/adityapandey9/rethinkdb-adapter/rethinkadapter.go:43:54: undefined: database
vendor/github.com/adityapandey9/rethinkdb-adapter/rethinkadapter.go:43:64: duplicate argument string
vendor/github.com/adityapandey9/rethinkdb-adapter/rethinkadapter.go:43:71: undefined: table
vendor/github.com/adityapandey9/rethinkdb-adapter/rethinkadapter.go:44:47: undefined: database
vendor/github.com/adityapandey9/rethinkdb-adapter/rethinkadapter.go:44:64: undefined: table
```